### PR TITLE
Fix Python 3.13 patch from #19

### DIFF
--- a/py313/armor-marshal.patch
+++ b/py313/armor-marshal.patch
@@ -23,6 +23,15 @@ index 1fb8cc4..3e1ab3b 100644
      /* mapping frame offsets to information */
      PyObject *localsplusnames;  // Tuple of strings
      PyObject *localspluskinds;  // Bytes object, one byte per variable
+@@ -315,7 +317,7 @@ extern void _PyCode_Clear_Executors(PyCodeObject *code);
+ // gh-115999 tracks progress on addressing this.
+ #define ENABLE_SPECIALIZATION 0
+ #else
+-#define ENABLE_SPECIALIZATION 1
++#define ENABLE_SPECIALIZATION 0
+ #endif
+ 
+ /* Specialization functions */
 diff --git a/Objects/codeobject.c b/Objects/codeobject.c
 index bdf6ee9..4a28f4a 100644
 --- a/Objects/codeobject.c


### PR DESCRIPTION
I haven't touched armored 3.13 samples in a while, so when I recently analyzed one, I suddenly hit a de-marshalling failure. This regression was introduced in #19, where untested change sought to reduce patch size was accidentally pushed after a successful unpacking. This PR reverts that mistake.